### PR TITLE
Updated Arch

### DIFF
--- a/cpmdetail.py
+++ b/cpmdetail.py
@@ -1,9 +1,7 @@
 import configparser
-from flask import render_template
 import models.match_detail
 import service.riotapi
 from errors.not_found_error import NotFoundError
-from myforms.nameform import NameForm
 
 JUNGLE_CS = "jungle_cs"
 
@@ -41,34 +39,10 @@ try:
         return detailed_matches_dict
 
 
-    def get_index_post():
-        form = NameForm()
-        if form.validate_on_submit():
-            game_tag = form.gametag.data
-            tag_line = form.tagline.data
-            try:
-                puuid = get_puuid(game_tag, tag_line)
-            except NotFoundError as ex:
-                return render_template('index.html', form=form, message=ex.message)
-
-            matches = get_matches(puuid)
-            matches_length = len(matches)
-            if matches_length <= 0:
-                message = str(f"No account found for: {game_tag}#{tag_line}. Check for typos and try again")
-                print(message)
-                return render_template('index.html', form=form, message=message)
-
-            if matches_length > 0:
-                message = str(f"Matches for: {game_tag}#{tag_line}")
-                print(message)
-                detailed_matches_dict = get_match_detail(matches, puuid)
-                return render_template('matches.html', form=form, message=message, matches_length=matches_length,
-                                       detailed_matches_dict=detailed_matches_dict, matches=matches, puuid=puuid)
-            else:
-                message = str(f"{game_tag}#{tag_line} found but no recent matches. Check for typos and try again")
-                print(message)
-                return render_template('index.html', form=form, message={message})
-
+    def get_matches_from_user_input(game_tag, tag_line):
+        puuid = service.riotapi.get_puuid(game_tag, tag_line, api_key)
+        matches = get_matches(puuid)
+        return {puuid: get_match_detail(matches, puuid)}
 
     def get_match_timeline(match_id):
         # get match timeline

--- a/cpmdetail.py
+++ b/cpmdetail.py
@@ -12,10 +12,6 @@ config.read_file(open(r'api-key.txt'))
 api_key = config.get('API Key', 'api_key')
 
 try:
-    def get_puuid(game_tag, tag_line):
-        return service.riotapi.get_puuid(game_tag, tag_line, api_key)
-
-
     def get_matches(puuid):
         return service.riotapi.get_matches(puuid, api_key, 5)
 
@@ -42,7 +38,7 @@ try:
     def get_matches_from_user_input(game_tag, tag_line):
         puuid = service.riotapi.get_puuid(game_tag, tag_line, api_key)
         matches = get_matches(puuid)
-        return {puuid: get_match_detail(matches, puuid)}
+        return get_match_detail(matches, puuid)
 
     def get_match_timeline(match_id):
         # get match timeline

--- a/cpmdetail.py
+++ b/cpmdetail.py
@@ -1,11 +1,9 @@
+import configparser
+from flask import render_template
 import models.match_detail
 import service.riotapi
-import configparser
-import datetime
-from datetime import datetime
-import time
-
 from errors.not_found_error import NotFoundError
+from myforms.nameform import NameForm
 
 JUNGLE_CS = "jungle_cs"
 
@@ -25,41 +23,62 @@ try:
 
 
     def get_match_detail(matches, puuid):
-        matches_dict = {}
+        detailed_matches_dict = {}
         for match in matches:
             match_id = match
-            data = service.riotapi.get_match_detail(match_id, api_key)
-            data['puuid'] = puuid
-            participants = data.get("info").get("participants")
-            participant = [item for (index, item) in enumerate(participants) if item.get("puuid") == puuid]
-            participant_detail = {k: v for e in participant for (k, v) in e.items()}
+            match_detail_dict = service.riotapi.get_match_detail(match_id, api_key)
+            match_detail_dict['puuid'] = puuid
+            participants_dict = match_detail_dict.get("info").get("participants")
+            participant_dict = [participant for (index, participant) in enumerate(participants_dict) if
+                                participant.get("puuid") == puuid]
+            participant_detail_dict = {k: v for participant_dict in participant_dict for (k, v) in
+                                       participant_dict.items()}
+            match_detail_dict = models.match_detail.merge(models.match_detail.MatchDetails(match_detail_dict),
+                                                          models.match_detail.ParticipantMatchDetails(
+                                                              participant_detail_dict))
+            detailed_matches_dict[match_id] = match_detail_dict
 
-            match_detail = models.match_detail.MatchDetails(data)
-
-            match_participant_detail = models.match_detail.ParticipantMatchDetails(participant_detail)
-
-            match_id_dict = models.match_detail.merge(match_detail,match_participant_detail)
-
-            matches_dict[match_id] = match_id_dict
-
-        return matches_dict
+        return detailed_matches_dict
 
 
-    def get_matches_ux(matches, puuid):
-        return service.riotapi.get_matches_ux(matches, puuid, api_key)
+    def get_index_post():
+        form = NameForm()
+        if form.validate_on_submit():
+            game_tag = form.gametag.data
+            tag_line = form.tagline.data
+            try:
+                puuid = get_puuid(game_tag, tag_line)
+            except NotFoundError as ex:
+                return render_template('index.html', form=form, message=ex.message)
 
+            matches = get_matches(puuid)
+            matches_length = len(matches)
+            if matches_length <= 0:
+                message = str(f"No account found for: {game_tag}#{tag_line}. Check for typos and try again")
+                print(message)
+                return render_template('index.html', form=form, message=message)
 
-    def get_participant(match_id, puuid):
-        # get participant id
-        return service.riotapi.get_users_participant_id(match_id, puuid, api_key)
+            if matches_length > 0:
+                message = str(f"Matches for: {game_tag}#{tag_line}")
+                print(message)
+                detailed_matches_dict = get_match_detail(matches, puuid)
+                return render_template('matches.html', form=form, message=message, matches_length=matches_length,
+                                       detailed_matches_dict=detailed_matches_dict, matches=matches, puuid=puuid)
+            else:
+                message = str(f"{game_tag}#{tag_line} found but no recent matches. Check for typos and try again")
+                print(message)
+                return render_template('index.html', form=form, message={message})
 
 
     def get_match_timeline(match_id):
         # get match timeline
         match_timeline = service.riotapi.get_match_timeline(match_id, api_key)
+
         return match_timeline.get("info").get("frames")
 
-    def get_cs_per_frame(participant_id, frames):
+
+    def get_cs_per_frame(participant_id, match_id):
+        frames = get_match_timeline(match_id)
         minute_count = 0
         minion_data_dict = {}
         for frame in frames:
@@ -73,7 +92,6 @@ try:
 
         lane_cs_previous_value = 0
         jungle_cs_previous_value = 0
-        total_cs = 0
         frame_count = 0
         output_dict = {}
         for frame in minion_data_dict:
@@ -85,7 +103,8 @@ try:
             lane_frame_diff = lane_cs - lane_cs_previous_value
             jungle_frame_diff = jungle_cs - jungle_cs_previous_value
 
-            output_dict[frame_count] = {"total": total_cs, "lane_diff": lane_frame_diff, "jungle_diff": jungle_frame_diff}
+            output_dict[frame_count] = {"total": total_cs, "lane_diff": lane_frame_diff,
+                                        "jungle_diff": jungle_frame_diff}
 
             # increments
             lane_cs_previous_value = lane_cs_previous_value + lane_frame_diff

--- a/errors/not_found_error.py
+++ b/errors/not_found_error.py
@@ -2,4 +2,3 @@ class NotFoundError(Exception):
     def __init__(self):
         self.message = "Item not found"
         super().__init__(self.message)
-

--- a/index.py
+++ b/index.py
@@ -40,9 +40,7 @@ def index_post():
         try:
             detailed_matches_dict = cpmdetail.get_matches_from_user_input(game_tag, tag_line)
             message = str(f"Matches for: {game_tag}#{tag_line}")
-            puuid = next(iter(detailed_matches_dict))
-            detailed_matches = detailed_matches_dict.get(puuid)
-            return render_template('matches.html', form=form, message=message, matches_length=len(detailed_matches), detailed_matches_dict=detailed_matches, puuid=puuid)
+            return render_template('matches.html', form=form, message=message, matches_length=len(detailed_matches_dict), detailed_matches_dict=detailed_matches_dict)
         except NotFoundError as ex:
             return render_template('index.html', form=form, message=ex.message)
     return render_template('index.html', form=form, message="Invalid Form")

--- a/input/userinput.py
+++ b/input/userinput.py
@@ -1,10 +1,7 @@
-#game tag
-game_tag="3nderWiggin"
-#tag_line
-tag_line="NA1"
-
 def getuser():
     user_input = dict()
     user_input['game_tag'] = input("Enter username as visible in game: ")
-    user_input['tag_line'] = input("Enter tag line without the leading #. This is the #value under your game name if you hover your profile picture. ")
+    user_input['tag_line'] = input(
+        "Enter tag line without the leading #. This is the #value under your game name if you hover your profile "
+        "picture. ")
     return user_input

--- a/models/match_detail.py
+++ b/models/match_detail.py
@@ -4,33 +4,36 @@ import time
 
 
 class MatchDetails:
-    def __init__(self, dict):
-        self.matchId = dict.get('metadata', {}).get('matchId')
-        self.gameCreation = (datetime.fromtimestamp(dict.get('info', {}).get('gameCreation') // 1000)).strftime("%m-%d %I:%M %p")
-        self.gameDuration = time.strftime('%H:%M:%S',time.gmtime(dict.get('info', {}).get('gameDuration')))
-        self.gameMode = dict.get('info', {}).get('gameMode')
-        self.puuid = dict.get("puuid")
+    def __init__(self, metadata):
+        self.matchId = metadata.get('metadata', {}).get('matchId')
+        self.gameCreation = (datetime.fromtimestamp(metadata.get('info', {}).get('gameCreation') // 1000)).strftime(
+            "%m-%d %I:%M %p")
+        self.gameDuration = time.strftime('%H:%M:%S', time.gmtime(metadata.get('info', {}).get('gameDuration')))
+        self.gameMode = metadata.get('info', {}).get('gameMode')
+        self.puuid = metadata.get("puuid")
 
-    def merge(self, dict):
-        return dict.update(self)
+    def merge(self, metadata):
+        return metadata.update(self)
+
 
 class ParticipantMatchDetails:
-    def __init__(self,dict):
-        self.kills = dict.get('kills')
-        self.deaths = dict.get('deaths')
-        self.assists = dict.get('assists')
-        self.kda = round(dict.get('challenges', {}).get('kda'))
-        self.deaths = dict.get('deaths')
-        self.championId = dict.get('championId')
-        self.championName = dict.get('championName')
-        self.championTransform = dict.get('championTransform')
-        self.lane = dict.get('lane')
-        self.role = dict.get('role')
-        self.individualPosition = dict.get('individualPosition')
-        self.win = dict.get('win')
-        self.participantId = dict.get('participantId')
-        self.riotIdGameName = dict.get('riotIdGameName')
-        self.puuid = dict.get('puuid')
+    def __init__(self, info):
+        self.kills = info.get('kills')
+        self.deaths = info.get('deaths')
+        self.assists = info.get('assists')
+        self.kda = round(info.get('challenges', {}).get('kda'), 1)
+        self.deaths = info.get('deaths')
+        self.championId = info.get('championId')
+        self.championName = info.get('championName')
+        self.championTransform = info.get('championTransform')
+        self.lane = info.get('lane')
+        self.role = info.get('role')
+        self.individualPosition = info.get('individualPosition')
+        self.win = 'Victory' if info.get('win') else 'Defeat'
+        self.participantId = info.get('participantId')
+        self.riotIdGameName = info.get('riotIdGameName')
+        self.puuid = info.get('puuid')
+
 
 def merge(obj1, obj2):
     obj1.__dict__.update(obj2.__dict__)

--- a/myforms/nameform.py
+++ b/myforms/nameform.py
@@ -5,5 +5,6 @@ from wtforms.validators import DataRequired, Length
 
 class NameForm(FlaskForm):
     gametag = StringField('Enter username as visible in game', validators=[DataRequired(), Length(3, 16)])
-    tagline = StringField('Enter tag line without the leading #. This is the #value under your game name if you hover your profile picture', validators=[DataRequired(), Length(3, 5)])
+    tagline = StringField('Enter tag line without the leading #. This is the #value under your game name if you hover '
+                          'your profile picture', validators=[DataRequired(), Length(3, 5)])
     submit = SubmitField('Submit')

--- a/service/riotapi.py
+++ b/service/riotapi.py
@@ -2,17 +2,20 @@ import requests
 
 from errors.not_found_error import NotFoundError
 
+
 def get_puuid(game_tag, tag_line, api_key):
     # get the puuid
-    get_puuid_url = str.format("https://americas.api.riotgames.com/riot/account/v1/accounts/by-riot-id/{0}/{1}?api_key={2}",
-                               game_tag, tag_line, api_key)
+    get_puuid_url = str.format(
+        "https://americas.api.riotgames.com/riot/account/v1/accounts/by-riot-id/{0}/{1}?api_key={2}",
+        game_tag, tag_line, api_key)
     puuid_response_dict = get_response_json(get_puuid_url)
     return puuid_response_dict.get("puuid")
 
 
 def get_last_match(puuid, api_key):
-    get_match_url = str.format("https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/{0}/ids?start=0&count=20&api_key={1}", puuid,
-               api_key)
+    get_match_url = str.format(
+        "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/{0}/ids?start=0&count=20&api_key={1}", puuid,
+        api_key)
     match_response_dict = get_response_json(get_match_url)
     return match_response_dict[0]
 
@@ -29,20 +32,6 @@ def get_match_detail(match_id, api_key):
     get_match_detail_url = str.format("https://americas.api.riotgames.com/lol/match/v5/matches/{0}?api_key={1}",
                                       match_id, api_key)
     return get_response_json(get_match_detail_url)
-
-
-def get_users_participant_id(match_id, puuid, api_key):
-    get_match_detail_url = str.format("https://americas.api.riotgames.com/lol/match/v5/matches/{0}?api_key={1}",
-                                      match_id, api_key)
-    match_detail_response_dict = get_response_json(get_match_detail_url)
-
-    participants = match_detail_response_dict.get("info").get("participants")
-
-    for participant in participants:
-        if participant.get("puuid") == puuid:
-            return participant.get("participantId")
-
-    print(f"Participant {puuid} not found in participant list for match {match_id}")
 
 
 def get_match_timeline(match_id, api_key):

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -14,7 +14,7 @@
 {% for k, v in detailed_matches_dict.items(): %}
 	<div class="container text-center pt-3 pb-3">
 		<div class="row clickable-row pt-2 pl-2 custom-click-row" >
-			<a href="{{ url_for('match', puuid = puuid, participant_id = v['participantId'] , match_id = v['matchId']) }}">Click here for more info!'</a>
+			<a href="{{ url_for('match', puuid = puuid, participant_id = v['participantId'] , match_id = v['matchId']) }}">Click here for more info!</a>
 			<div class="col-md-12">
 				<div class="row">
 					<div class="col-md-6">

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -11,10 +11,10 @@
   </div>
 </div>
 
-{% for k, v in match_detail_dict.items(): %}
+{% for k, v in detailed_matches_dict.items(): %}
 	<div class="container text-center pt-3 pb-3">
-		<div class="row clickable-row pt-2 custom-click-row" >
-			<a href="{{ url_for('match', puuid = puuid, id = v['matchId']) }}">{{v['matchId']}}</a>
+		<div class="row clickable-row pt-2 pl-2 custom-click-row" >
+			<a href="{{ url_for('match', puuid = puuid, participant_id = v['participantId'] , match_id = v['matchId']) }}">Click here for more info!'</a>
 			<div class="col-md-12">
 				<div class="row">
 					<div class="col-md-6">
@@ -42,7 +42,7 @@
 					<div class="col-md-6">
 						<div class="row">
 							<div class="col-md-6">
-								<p><strong>Victory: </strong>{{v['win']}}</p>
+								<p><strong>{{v['win']}}</strong></p>
 							</div>
 							<div class="col-sm-3">
 								<p><strong>KDA</strong> {{v['kda']}}</p>

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -14,7 +14,7 @@
 {% for k, v in detailed_matches_dict.items(): %}
 	<div class="container text-center pt-3 pb-3">
 		<div class="row clickable-row pt-2 pl-2 custom-click-row" >
-			<a href="{{ url_for('match', puuid = puuid, participant_id = v['participantId'] , match_id = v['matchId']) }}">Click here for more info!</a>
+			<a href="{{ url_for('match', puuid = v['puuid'], participant_id = v['participantId'] , match_id = v['matchId']) }}">Click here for more info!</a>
 			<div class="col-md-12">
 				<div class="row">
 					<div class="col-md-6">


### PR DESCRIPTION
Trello: Victory: True/False -> Victory/Defeat

Trello: Link to match detail screen is not obvious  < I want to make the row for each match clickable eventually.

Moved some @app.route('/') logic to to CPMDetails.py. Added import items to allow and send back the Render_Template call and options to index_post on index.py when the logic moved to CPMDetail decides what to send back as the Render_Template.  

^^^^ I expect this alone to fail the branch and cause a heart attack. It didn't work like I had planned, but does work how it is. 

Moved some get_match logic to CPMDetail.py from Index.py
Changed logic to call get_cs_per_frame, then call get_match_timeline, then RiotAPI 

Expanded on method in matches.html to grab and hand off the Participant_ID get_match.

Removed get_participant from CPMDetail.py and related RiotAPI.py

modified matches.html and match_detail.py to shoe Victory or Defeat instead of True False.

Used Pycharm hints on files to clear warnings on files with space or length violations. 
This also cause a removal of dead imports and variable naming in match_detail.py and get_match_detail on CPMDetail.py.

Mostly due to shadowing and some requested clarification on element names used in the faction previous.   

Majority of the changes are a result of our discussion earlier today. I realize that pull requests should be one item per request. So I expect kickback in this Pull Req. XD
